### PR TITLE
GenerateSecret kinda generates a secret

### DIFF
--- a/it_test.go
+++ b/it_test.go
@@ -357,14 +357,21 @@ func TestWaitFor(t *testing.T) {
 
 // TestGenerateSecret tests secret generation
 func TestGenerateSecret(t *testing.T) {
-	secret1 := it.GenerateSecret()
-	secret2 := it.GenerateSecret()
-
-	if secret1 == "" {
-		t.Error("GenerateSecret returned empty string")
-	}
-	if secret1 == secret2 {
-		t.Error("Generated secrets should be different")
+	for secretLength := 4; secretLength <= 16; secretLength++ {
+		seenSecrets := make(map[string]struct{})
+		// Technically, duplicate secrets could be produced even 
+		// if working properly, but it's relatively unlikely.
+		for i := 0; i < 10; i++ {
+			secret := it.GenerateSecret(secretLength)
+			expectedLength := secretLength * 2
+			if len(secret) != expectedLength {
+				t.Errorf("Secret length mismatch. Should be %d, got %d", expectedLength, len(secret))
+			}
+			if _, ok := seenSecrets[secret]; ok {
+				t.Errorf("Duplicate secret generated: %s", secret)
+			}
+			seenSecrets[secret] = struct{}{}
+		}
 	}
 }
 


### PR DESCRIPTION
Haha bet you didn't expect getting a PR for this.

I have no reason to contribute other than I just love the idea behind this package, and I think you are doing a cool thing. Hopefully this can spark some further development by others to make this package into something that's used for real reasons by a real person, somewhere.

Anyways, just looking through this I noticed that `GenerateSecret()` should use `crypto/rand`, and in the very rare error case the current implementation does not persist the 4-byte length requirement.

I also made it so you can generate hex with arbitrary length, but you can remove that if you want (along with the whole ass PR) 🙂

Keep it up!